### PR TITLE
Fix(employee): Handle JSON parse error in create-employee function

### DIFF
--- a/supabase/functions/create-employee/index.ts
+++ b/supabase/functions/create-employee/index.ts
@@ -40,7 +40,22 @@ serve(async (req) => {
       )
     }
 
-    const { employeeData } = await req.json()
+    let employeeData;
+    try {
+      const body = await req.json();
+      employeeData = body.employeeData;
+      if (!employeeData) {
+        throw new Error("employeeData is missing in the request body");
+      }
+    } catch (e) {
+      return new Response(
+        JSON.stringify({ error: `Error parsing request body: ${e.message}` }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        }
+      )
+    }
 
     // Create the auth user for the employee
     const { data: authData, error: authError } = await supabaseAdmin.auth.admin.createUser({


### PR DESCRIPTION
This commit fixes a bug where the `create-employee` Edge Function would crash with a `JSON.parse: unexpected end of data` error if the request body was empty or malformed.

I've wrapped the `req.json()` call in a `try-catch` block to gracefully handle parsing errors and return a meaningful JSON error response.