### PR TITLE
Fix(employee): Improve frontend error handling

### DIFF
--- a/src/components/company/EmployeesModule.tsx
+++ b/src/components/company/EmployeesModule.tsx
@@ -203,11 +203,17 @@ export const EmployeesModule = () => {
           body: JSON.stringify({ employeeData }),
         });
 
-        const result = await response.json();
-        
         if (!response.ok) {
-          throw new Error(result.error || 'Error al crear empleado');
+          const errorText = await response.text();
+          try {
+            const errorJson = JSON.parse(errorText);
+            throw new Error(errorJson.error || `Error del servidor: ${errorText}`);
+          } catch (e) {
+            throw new Error(`Error del servidor: ${errorText}`);
+          }
         }
+
+        const result = await response.json();
 
         toast.success('Empleado creado exitosamente');
       }


### PR DESCRIPTION
This commit improves the error handling in the `EmployeesModule` component. Previously, the code would always try to parse the response from the `create-employee` Edge Function as JSON, even if the request failed. This would cause a `JSON.parse` error if the server returned a non-JSON response (e.g., an HTML error page).

The new code now checks if the response is `ok` before attempting to parse it as JSON. If the response is not `ok`, it reads the response as text and includes it in the error message, providing more context about the error.