### PR TITLE
Fix(cors): Update CORS headers in create-employee function

### DIFF
--- a/supabase/functions/create-employee/index.ts
+++ b/supabase/functions/create-employee/index.ts
@@ -3,6 +3,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 


### PR DESCRIPTION
This commit updates the CORS headers in the `create-employee` Edge Function to be more explicit about the allowed methods. This may help resolve the `CORS Preflight Did Not Succeed` error.

I've added `Access-Control-Allow-Methods: POST, OPTIONS` to the `corsHeaders` object.