### PR TITLE
Fix(cors): Setup Netlify proxy for Supabase functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/api/*"
+  to = "https://jabiezfpkfyzfpiswcwz.supabase.co/functions/v1/:splat"
+  status = 200
+  force = true

--- a/src/components/company/EmployeesModule.tsx
+++ b/src/components/company/EmployeesModule.tsx
@@ -194,7 +194,7 @@ export const EmployeesModule = () => {
 
         const { data: session } = await supabase.auth.getSession();
         
-        const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/create-employee`, {
+        const response = await fetch(`/api/create-employee`, {
           method: 'POST',
           headers: {
             'Authorization': `Bearer ${session.session?.access_token}`,


### PR DESCRIPTION
This commit introduces a Netlify proxy to resolve CORS issues when calling Supabase Edge Functions.

A `netlify.toml` file has been added to configure a redirect from `/api/*` to the Supabase functions URL. The frontend code in `EmployeesModule.tsx` has been updated to use this new proxy endpoint.

This approach avoids CORS preflight errors by making the requests appear to come from the same origin.