### PR TITLE
Fix(vite): Add proxy to Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      '/api': {
+        target: 'https://jabiezfpkfyzfpiswcwz.supabase.co',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '/functions/v1'),
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
This commit adds a proxy to the Vite configuration to resolve 404 errors in the local development environment.

The proxy forwards requests from `/api` to the Supabase Edge Functions URL, ensuring that API calls work seamlessly in both local development and production (via Netlify redirects).