### PR TITLE
Fix(vite): Update proxy configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,9 +10,9 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
     proxy: {
       '/api': {
-        target: 'https://jabiezfpkfyzfpiswcwz.supabase.co',
+        target: 'https://jabiezfpkfyzfpiswcwz.supabase.co/functions/v1',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '/functions/v1'),
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
This commit updates the Vite proxy configuration to be more explicit.

The `target` now includes the full path to the Supabase functions, and the `rewrite` function simply removes the `/api` prefix. This change may help resolve issues with the proxy not forwarding requests correctly.