### PR TITLE
Fix: Associate employee with company

### DIFF
--- a/src/components/company/EmployeesModule.tsx
+++ b/src/components/company/EmployeesModule.tsx
@@ -47,6 +47,7 @@ const employeeSchema = z.object({
   hire_date: z.string().optional(),
   role: z.enum(['admin', 'manager', 'employee', 'collector', 'accountant']).default('employee'),
   password: z.string().min(6, 'La contraseña debe tener al menos 6 caracteres'),
+  company_id: z.string().optional(),
 });
 
 type EmployeeFormData = z.infer<typeof employeeSchema>;
@@ -65,8 +66,9 @@ interface Employee {
   role: string;
   permissions: any;
   company_owner_id: string | null;
-  auth_user_id: string | null;
+  auth__id: string | null;
   created_at: string;
+  company_id: string | null;
 }
 
 interface PermissionConfig {
@@ -190,6 +192,7 @@ export const EmployeesModule = () => {
         const employeeData = {
           ...data,
           permissions: selectedPermissions.reduce((acc, perm) => ({ ...acc, [perm]: true }), {}),
+          company_id: user.user_metadata.company_id,
         };
 
         const { data: session } = await supabase.auth.getSession();

--- a/supabase/functions/create-employee/index.ts
+++ b/supabase/functions/create-employee/index.ts
@@ -66,7 +66,7 @@ serve(async (req) => {
       user_metadata: {
         full_name: employeeData.full_name,
         role: employeeData.role,
-        company_owner_id: user.id,
+        company_id: employeeData.company_id,
       }
     })
 
@@ -97,6 +97,7 @@ serve(async (req) => {
         role: employeeData.role,
         status: 'active',
         permissions: employeeData.permissions || {},
+        company_id: employeeData.company_id,
       })
 
     if (employeeError) {


### PR DESCRIPTION
This commit fixes an issue where newly created employees were not associated with the company of the user who created them.

The `create-employee` Supabase function has been updated to accept a `company_id` and use it to set the `company_id` in the new user's metadata and in the `employees` table.

The `EmployeesModule.tsx` component has been updated to pass the `company_id` of the currently logged-in user when creating a new employee.