### PR TITLE
Feat: Implement multi-tenant data access

### DIFF
--- a/src/components/clients/ClientsModule.tsx
+++ b/src/components/clients/ClientsModule.tsx
@@ -45,23 +45,25 @@ export const ClientsModule = () => {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedClient, setSelectedClient] = useState<Client | null>(null);
-  const { user } = useAuth();
+  const { user, companyId } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetchClients();
-  }, [user]);
+    if (companyId) {
+      fetchClients();
+    }
+  }, [companyId]);
 
   const fetchClients = async () => {
-    if (!user) return;
+    if (!companyId) return;
 
     try {
       setLoading(true);
-      console.log('Fetching clients for user:', user.id);
       
       const { data, error } = await supabase
         .from('clients')
         .select('*')
+        .eq('company_id', companyId)
         .order('created_at', { ascending: false });
 
       if (error) {

--- a/src/components/company/EmployeesModule.tsx
+++ b/src/components/company/EmployeesModule.tsx
@@ -120,7 +120,7 @@ export const EmployeesModule = () => {
   const [editingEmployee, setEditingEmployee] = useState<Employee | null>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [selectedPermissions, setSelectedPermissions] = useState<string[]>([]);
-  const { user } = useAuth();
+  const { user, companyId } = useAuth();
 
   const form = useForm<EmployeeFormData>({
     resolver: zodResolver(employeeSchema),
@@ -131,17 +131,19 @@ export const EmployeesModule = () => {
   });
 
   useEffect(() => {
-    fetchEmployees();
-  }, []);
+    if (companyId) {
+      fetchEmployees();
+    }
+  }, [companyId]);
 
   const fetchEmployees = async () => {
-    if (!user) return;
+    if (!companyId) return;
 
     try {
       const { data, error } = await supabase
         .from('employees')
         .select('*')
-        .eq('company_owner_id', user.id)
+        .eq('company_id', companyId)
         .order('created_at', { ascending: false });
 
       if (error) {
@@ -192,7 +194,7 @@ export const EmployeesModule = () => {
         const employeeData = {
           ...data,
           permissions: selectedPermissions.reduce((acc, perm) => ({ ...acc, [perm]: true }), {}),
-          company_id: user.user_metadata.company_id,
+          company_id: companyId,
         };
 
         const { data: session } = await supabase.auth.getSession();

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -9,6 +9,7 @@ interface AuthContextType {
   session: Session | null;
   profile: any | null;
   loading: boolean;
+  companyId: string | null;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (data: RegisterData) => Promise<void>;
   signOut: () => Promise<void>;
@@ -29,6 +30,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [profile, setProfile] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
+  const [companyId, setCompanyId] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -52,6 +54,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           }, 0);
         } else {
           setProfile(null);
+          setCompanyId(null);
         }
         
         setLoading(false);
@@ -117,6 +120,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           company_id: employeeData.company_id,
           is_employee: true
         });
+        setCompanyId(employeeData.company_id);
         setLoading(false);
         return;
       }
@@ -138,6 +142,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         ...data,
         is_employee: false
       });
+      setCompanyId(data.id);
     } catch (error) {
       console.error('Error in fetchProfile:', error);
     } finally {
@@ -206,6 +211,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     session,
     profile,
     loading,
+    companyId,
     signIn,
     signUp,
     signOut,

--- a/src/hooks/useLoans.tsx
+++ b/src/hooks/useLoans.tsx
@@ -24,10 +24,10 @@ export interface Loan {
 export const useLoans = () => {
   const [loans, setLoans] = useState<Loan[]>([]);
   const [loading, setLoading] = useState(true);
-  const { user } = useAuth();
+  const { companyId } = useAuth();
 
   const fetchLoans = async () => {
-    if (!user) return;
+    if (!companyId) return;
 
     try {
       const { data, error } = await supabase
@@ -39,6 +39,7 @@ export const useLoans = () => {
             dni
           )
         `)
+        .eq('company_id', companyId)
         .order('created_at', { ascending: false });
 
       if (error) {
@@ -56,8 +57,10 @@ export const useLoans = () => {
   };
 
   useEffect(() => {
-    fetchLoans();
-  }, [user]);
+    if (companyId) {
+      fetchLoans();
+    }
+  }, [companyId]);
 
   return {
     loans,


### PR DESCRIPTION
This commit refactors the application to support multi-tenant data access, where employees can access the data of the company that created them.

The `useAuth` hook has been updated to expose a `companyId` that is used throughout the application to filter data. This `companyId` is set to the employee's `company_id` if the user is an employee, or to the user's own ID if they are a company owner.

The `EmployeesModule`, `LoansModule`, and `ClientsModule` have been updated to use this new `companyId` for all their Supabase queries. This ensures that all data is correctly scoped to the user's company.